### PR TITLE
Fix duplicate requests in picsur-img.component

### DIFF
--- a/frontend/src/app/components/picsur-img/picsur-img.component.html
+++ b/frontend/src/app/components/picsur-img/picsur-img.component.html
@@ -16,5 +16,5 @@
 <mat-spinner
   (nguiInview)="onInview($event)"
   (nguiOutview)="onOutview($event)"
-  *ngIf="state === 'loading'"
+  *ngIf="state === 'init' || state === 'loading'"
 ></mat-spinner>

--- a/frontend/src/app/components/picsur-img/picsur-img.component.ts
+++ b/frontend/src/app/components/picsur-img/picsur-img.component.ts
@@ -17,6 +17,7 @@ import { Logger } from 'src/app/services/logger/logger.service';
 import { QoiWorkerService } from 'src/app/workers/qoi-worker.service';
 
 enum PicsurImgState {
+  Init = 'init',
   Loading = 'loading',
   Canvas = 'canvas',
   Image = 'image',
@@ -39,7 +40,7 @@ export class PicsurImgComponent implements OnChanges {
 
   @Input('src') imageURL: string | undefined;
 
-  public state: PicsurImgState = PicsurImgState.Loading;
+  public state: PicsurImgState = PicsurImgState.Init;
 
   constructor(
     private readonly qoiWorker: QoiWorkerService,
@@ -113,7 +114,8 @@ export class PicsurImgComponent implements OnChanges {
   onInview(e: any) {
     this.isInView = true;
 
-    if (this.state === PicsurImgState.Loading) {
+    if (this.state === PicsurImgState.Init) {
+      this.state = PicsurImgState.Loading;
       this.reload();
     }
   }


### PR DESCRIPTION
This is caused by an improper initial state (Loading) that triggers `onInview` multiple times while images are still in the loading state.

Before the fix, the network logs in My Images view:

![image](https://user-images.githubusercontent.com/30596812/224550299-f2159a86-821b-4cf7-8b0f-07fd4edcc8d5.png)

After the fix:

![image](https://user-images.githubusercontent.com/30596812/224550374-851c01bc-4890-4896-b643-ff0b688ef39f.png)
